### PR TITLE
New balance messages

### DIFF
--- a/src/handlers/coinBalance.js
+++ b/src/handlers/coinBalance.js
@@ -4,8 +4,32 @@ const slackTextResponse = require('../utils/slackTextResponse')
 
 const sendToSender = async (sender, responseUrl) => {
   const remainingCoins = await coinRepository.remainingCoins(sender)
-  const message = slackTextResponse.private(`Il tuo saldo residuo è di ${remainingCoins} Flowing Coins`)
+  const message = balanceMessage(sender, remainingCoins)
   await slackApiClient.sendMessage(message, responseUrl)
+}
+
+const balanceMessage = (sender, remainingCoins) => {
+  if (remainingCoins === 0) {
+    return emptyBalanceMessage(sender)
+  }
+
+  if (remainingCoins < 5) {
+    return quiteEmptyBalanceMessage(sender, remainingCoins)
+  }
+
+  return avgBalanceMessage(sender, remainingCoins)
+}
+
+const avgBalanceMessage = (sender, remainingCoins) => {
+  return slackTextResponse.private(`:heavy_dollar_sign::heavy_dollar_sign::heavy_dollar_sign:\nCiao ${sender} \necco il tuo saldo residuo: *${remainingCoins} Flowing Coins* \n:heavy_dollar_sign::heavy_dollar_sign::heavy_dollar_sign:`)
+}
+
+const quiteEmptyBalanceMessage = (sender, remainingCoins) => {
+  return slackTextResponse.private(`:eyes: Ehi ${sender} \ntieni sott'occhio il tuo saldo residuo. Restano solo *${remainingCoins} Flowing Coins* :eyes:`)
+}
+
+const emptyBalanceMessage = (sender) => {
+  return slackTextResponse.private(`:gratitude-thank-you: ${sender} \nhai usato tutti i tuoi Flowing Coins. Ora puoi dire grazie con una :beer:`)
 }
 
 module.exports = {


### PR DESCRIPTION
Vengono differenziati i messaggi del saldo in base al numero di coins rimanenti:

se i coins restanti sono >=5 il messaggio è:
<img width="365" alt="Screenshot 2022-03-02 at 17 39 50" src="https://user-images.githubusercontent.com/15413007/156406711-5bfd43df-bd6e-4f88-9dc4-c163e21e1e4c.png">

tra 1 e 4 il messaggio è:
<img width="546" alt="Screenshot 2022-03-02 at 17 41 02" src="https://user-images.githubusercontent.com/15413007/156406962-fc6e3afa-296c-4f0c-bce7-336f0406eb4a.png">

se finiscono:
<img width="524" alt="Screenshot 2022-03-02 at 17 41 23" src="https://user-images.githubusercontent.com/15413007/156407031-d9bbed53-2dd1-45c8-b734-449bb1d492ee.png">

L'utilità della modifica sta nella modifica stessa.
